### PR TITLE
Use style proptype

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { View } from 'react-native';
 import Pie from './Pie.js';
 
 class PieChart extends Component {
@@ -31,7 +32,7 @@ PieChart.propTypes = {
   doughnut: React.PropTypes.bool,
   series: React.PropTypes.array.isRequired,
   sliceColor: React.PropTypes.array.isRequired,
-  style: React.PropTypes.object,
+  style: View.propTypes.style,
 };
 
 PieChart.defaultProps = {


### PR DESCRIPTION
As described here: https://facebook.github.io/react-native/releases/0.21/docs/style.html#pass-styles-around, we should pass styles around using the style proptype. This is because we may want to define the style to be passed in within our `StyleSheet.create`, which returns a number for the style.